### PR TITLE
Applying too many arguments to a function object

### DIFF
--- a/Epic/CodegenC.lhs
+++ b/Epic/CodegenC.lhs
@@ -20,8 +20,8 @@
 
 > writeIFace :: [Decl] -> String
 > writeIFace [] = ""
-> writeIFace ((Decl name ret (Bind args _ _ _) _ _):xs) =
->     "extern " ++ showC name ++ " ("++ showextargs (args) ++ ")" ++
+> writeIFace ((Decl (UN name) ret (Bind args _ _ _) _ _):xs) =
+>     "extern " ++ name ++ " ("++ showextargs (args) ++ ")" ++
 >               " -> " ++ show ret ++ "\n" ++ writeIFace xs
 > writeIFace (_:xs) = writeIFace xs
 

--- a/evm/closure.c
+++ b/evm/closure.c
@@ -534,7 +534,7 @@ inline VAL CLOSURE_ADD5(VAL xin, VAL a1, VAL a2, VAL a3, VAL a4, VAL a5)
     fn->arg_end[2] = a3;
     fn->arg_end[3] = a4;
     fn->arg_end[4] = a5;
-    fn->arg_end+=2;
+    fn->arg_end+=5;
 
     return x;
 }
@@ -684,7 +684,9 @@ inline VAL CLOSURE_APPLY1(VAL f, VAL a1)
 	    block[got] = a1;
 	    return (VAL)(finf->fn(block));
 	}
-	else return CLOSURE_ADD1(f,a1);
+	else if (finf->arity < (got+1)) {
+	    return (VAL) DO_EVAL(CLOSURE_ADD1(f,a1), 0);
+	}	else return CLOSURE_ADD1(f,a1);
     }
     else return aux_CLOSURE_APPLY1(f,a1);
 }
@@ -705,8 +707,9 @@ inline VAL CLOSURE_APPLY2(VAL f, VAL a1, VAL a2)
 	    block[got] = a1;
 	    block[got+1] = a2;
 	    return (VAL)(finf->fn(block));
-	}
-	else return CLOSURE_ADD2(f,a1,a2);
+	} else if (finf->arity < (got+2)) {
+	    return (VAL) DO_EVAL(CLOSURE_ADD2(f,a1,a2), 0);
+	}	else return CLOSURE_ADD2(f,a1,a2);
     }
     else return aux_CLOSURE_APPLY2(f,a1,a2);
 }
@@ -724,7 +727,9 @@ inline VAL CLOSURE_APPLY3(VAL f, VAL a1, VAL a2, VAL a3)
 	    block[got+2] = a3;
 	    return (VAL)(finf->fn(block));
 	}
-	else return CLOSURE_ADD3(f,a1,a2,a3);
+	else if (finf->arity < (got+3)) {
+	    return (VAL) DO_EVAL(CLOSURE_ADD3(f,a1,a2,a3), 0);
+	}	else return CLOSURE_ADD3(f,a1,a2,a3);
     }
     else return aux_CLOSURE_APPLY3(f,a1,a2,a3);
 }
@@ -743,7 +748,9 @@ inline VAL CLOSURE_APPLY4(VAL f, VAL a1, VAL a2, VAL a3, VAL a4)
 	    block[got+3] = a4;
 	    return (VAL)(finf->fn(block));
 	}
-	else return CLOSURE_ADD4(f,a1,a2,a3,a4);
+	else if (finf->arity < (got+4)) {
+	    return (VAL) DO_EVAL(CLOSURE_ADD4(f,a1,a2,a3,a4), 0);
+	}	else return CLOSURE_ADD4(f,a1,a2,a3,a4);
     }
     else return aux_CLOSURE_APPLY4(f,a1,a2,a3,a4);
 }
@@ -763,7 +770,9 @@ inline VAL CLOSURE_APPLY5(VAL f, VAL a1, VAL a2, VAL a3, VAL a4, VAL a5)
 	    block[got+4] = a5;
 	    return (VAL)(finf->fn(block));
 	}
-	else return CLOSURE_ADD5(f,a1,a2,a3,a4,a5);
+	else if (finf->arity < (got+5)) {
+	    return (VAL) DO_EVAL(CLOSURE_ADD5(f,a1,a2,a3,a4,a5), 0);
+	}	else return CLOSURE_ADD5(f,a1,a2,a3,a4,a5);
     }
     else return aux_CLOSURE_APPLY5(f,a1,a2,a3,a4,a5);
 }
@@ -783,6 +792,7 @@ VAL DO_EVAL(VAL x, int update) {
     switch(GETTY(x)) {
     case CON:
     case INT:
+    case BIGINT:
     case FLOAT:
     case STRING:
     case PTR:


### PR DESCRIPTION
Hello Edwin!

It's us again.

Consider the following program:

printNat(x : Any) -> Any = foreign Unit "printBig" (x : BigInt)
plus (x : Any, y : Any) -> Any = foreign BigInt "addBig" (x : BigInt, y : BigInt)

kk (x : Any , y : Any) -> Any = x

apply( f : Any, x : Any) -> Any = f(unit, x)

inc (x : Any) -> Any = plus(x, 1L)

main () -> Unit = printNat (apply(kk (inc), 0L))

In the compiled code the apply function will apply (kk (inc)) to two arguments using CLOSURE_APPLY2, but (kk (inc)) only takes one argument and the result of that is a function object which takes the other argument. In this patch we seem to have fixed this, but we are unsure if this will work in general. What do you think?

Kind regards,
Olle and Daniel

=== Commit message
CLOSURE_APPLYn when applied to a function requiring less than n arguments
will now call DO_EVAL which will do the right thing in that case.
This seems to work.

Added BIGINT to DO_EVAL as an already evaluated value.

Changed the code generator so names for imports are not doubly encoded.
