### PR TITLE
Removed dependency on haskell98

### DIFF
--- a/Epic/Epic.lhs
+++ b/Epic/Epic.lhs
@@ -45,7 +45,7 @@
 Combinators for constructing an expression
 
 > import Control.Monad.State
-> import System
+> import System.Process
 > import System.IO
 > import Debug.Trace
 

--- a/Epic/Stackcode.lhs
+++ b/Epic/Stackcode.lhs
@@ -1,7 +1,7 @@
 > module Epic.Stackcode where
 
 > import Control.Monad.State
-> import List
+> import Data.List
 
 > import Epic.Language
 > import Debug.Trace

--- a/epic.cabal
+++ b/epic.cabal
@@ -28,7 +28,7 @@ Library
                        Epic.Language Epic.Lexer Epic.CodegenC Epic.CodegenStack
                        Epic.OTTLang Epic.Simplify Epic.Stackcode 
                        Epic.Evaluator Paths_epic
-        Build-depends:	base >=4 && <5 , haskell98, mtl, Cabal, array, directory, process
+        Build-depends:	base >=4 && <5 , mtl, Cabal, array, directory, process
         Extensions:    BangPatterns
 
 Executable     epic
@@ -37,5 +37,5 @@ Executable     epic
                        Epic.Language Epic.Lexer Epic.CodegenC Epic.CodegenStack
                        Epic.OTTLang Epic.Simplify Epic.Stackcode 
                        Epic.Evaluator Paths_epic
-               Build-depends: base >=4 && <5, mtl, array, haskell98, Cabal, directory, process
+               Build-depends: base >=4 && <5, mtl, array, Cabal, directory, process
                Extensions: BangPatterns


### PR DESCRIPTION
I had problems installing Epic with GHC 7.2.1. I fixed the problem removing the dependency on Haskell 98.
