### PR TITLE
Use System.FilePath.replaceExtension in Main

### DIFF
--- a/Main.lhs
+++ b/Main.lhs
@@ -1,6 +1,7 @@
 > module Main where
 
 > import System.Exit
+> import System.FilePath
 > import System.Directory
 > import System.Environment
 > import System.IO
@@ -38,8 +39,8 @@
 > compileFiles [] _ = return []
 > compileFiles (fn:xs) opts
 >     | isDotE fn = do
->        let ofile = getRoot fn ++ ".o"
->        compileOpts fn ofile (Just (getRoot fn ++ ".ei")) opts
+>        let ofile = replaceExtension fn "o"
+>        compileOpts fn ofile (Just (replaceExtension fn "ei")) opts
 >        rest <- compileFiles xs opts
 >        return (ofile:rest)
 >     | isDotO fn = do
@@ -67,14 +68,11 @@
 >     (stem,".e") -> stem
 >     (stem,_) -> fn ++ ".exe"
 
-> getRoot fn = case span (/='.') fn of
->     (stem,_) -> stem
-
 > getInput :: [String] -> IO ([FilePath],[Option])
 > getInput args = do let opts = parseArgs args
 >                    processFlags opts False
 >                    fns <- getFile opts
->                    if (length fns == 0) 
+>                    if (length fns == 0)
 >                       then do showUsage
 >                               return (fns,opts)
 >                       else return (fns,opts)

--- a/epic.cabal
+++ b/epic.cabal
@@ -43,5 +43,5 @@ Executable     epic
                        Epic.Language Epic.Lexer Epic.CodegenC Epic.CodegenStack
                        Epic.OTTLang Epic.Simplify Epic.Stackcode
                        Epic.Evaluator Paths_epic
-               Build-depends: base >=4 && <5, mtl, array, Cabal, directory, process
+               Build-depends: base >=4 && <5, mtl, array, Cabal, directory, process, filepath
                Extensions: BangPatterns


### PR DESCRIPTION
Previously, the `epic` executable had its own logic to strip an
extension, by splitting on the `.` character. However, this logic would
split on the _first_ `.`, when it should split on the _last_ `.`. This
leads to problems, such as:

```
$ epic /nix/store/r7dwf24y88bwdzfb1s9cwk3sm35pcnwg-haskell-Agda-ghc7.8.3-2.4.2-shared/share/x86_64-linux-ghc-7.8.3/Agda-2.4.2/EpicInclude/AgdaPrelude.e
Fatal error: can't create /nix/store/r7dwf24y88bwdzfb1s9cwk3sm35pcnwg-haskell-Agda-ghc7.o: Read-only file system
```

Which is not the output path that we would expect.

Rather than reinventing the wheel and implementing file path handling
ourselves, we now depend on `filepath` for this logic. `filepath` is
already a transitive dependency, so the dependency graph is unchanged
with this change.
